### PR TITLE
【Fixed】`rails g`コマンドの際にいらないファイルが生成されないようにする

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,12 @@ module Achieve
         request_specs: false
       g.fixture_replacement :factory_girl, dir: "spec/factories"
     end
+    
+    # Improved the method on application.rb not to generate helper or assets with rails generate controller
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
+
   end
 end


### PR DESCRIPTION
#1
rails generate controller で無駄な helper や assets を生成しないように変更。
application.rbに以下の処理を追加。
```
config.generators do |g|
      g.assets     false
      g.helper     false
end
```